### PR TITLE
Check for Windows returns false positive on Darwin

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -96,7 +96,7 @@ exports.installDeps = function (options) {
   if (options.useYarn) {
     result = spawnSync('yarn', { stdio: 'inherit' });
   } else {
-    var npm = os.platform().indexOf('win') !== -1 ? 'npm.cmd' : 'npm';
+    var npm = os.platform().indexOf('win32') !== -1 ? 'npm.cmd' : 'npm';
     result = spawnSync(npm, ['install'], { stdio: 'inherit' });
   }
 


### PR DESCRIPTION
`os.platform().indexOf('win')` at https://github.com/ui-storybook/sb-cli/blob/master/lib/helpers.js#L99 returns true if running `sb-create` on a Mac (Darwin) and runs `npm.cmd install` as if OS is Windows.

Changing the substring to 'win32' will return true if Windows, false if Darwin.